### PR TITLE
Update BrowserWindow to enable webview

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
+      webviewTag: true,
     },
   });
 


### PR DESCRIPTION
## Summary
- allow `<webview>` tag usage by enabling `webviewTag` in BrowserWindow options

## Testing
- `npm install`
- `npm start` *(fails: Running as root without --no-sandbox is not supported)*
- `npx electron --no-sandbox .` *(fails: Missing X server or $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684cd47072b88325abdf4474ccbb2a83